### PR TITLE
New build with the correct links for the Improve this Doc button

### DIFF
--- a/contributing/current-status.html
+++ b/contributing/current-status.html
@@ -85,7 +85,7 @@
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/Shazwazza/lucenenet/blob/docfx-apidocs/websites/site/contributing/current-status.md/#L1" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/apache/lucenenet/blob/master/websites/site/contributing/current-status.md/#L1" class="contribution-link">Improve this Doc</a>
                   </li>
                 </ul>
               </div>

--- a/contributing/documentation.html
+++ b/contributing/documentation.html
@@ -121,7 +121,7 @@
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/Shazwazza/lucenenet/blob/docfx-apidocs/websites/site/contributing/documentation.md/#L1" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/apache/lucenenet/blob/master/websites/site/contributing/documentation.md/#L1" class="contribution-link">Improve this Doc</a>
                   </li>
                 </ul>
               </div>

--- a/contributing/index.html
+++ b/contributing/index.html
@@ -105,7 +105,7 @@
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/Shazwazza/lucenenet/blob/docfx-apidocs/websites/site/contributing/index.md/#L1" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/apache/lucenenet/blob/master/websites/site/contributing/index.md/#L1" class="contribution-link">Improve this Doc</a>
                   </li>
                 </ul>
               </div>

--- a/contributing/issue-tracker.html
+++ b/contributing/issue-tracker.html
@@ -83,7 +83,7 @@
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/Shazwazza/lucenenet/blob/docfx-apidocs/websites/site/contributing/issue-tracker.md/#L1" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/apache/lucenenet/blob/master/websites/site/contributing/issue-tracker.md/#L1" class="contribution-link">Improve this Doc</a>
                   </li>
                 </ul>
               </div>

--- a/contributing/mailing-lists.html
+++ b/contributing/mailing-lists.html
@@ -95,7 +95,7 @@
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/Shazwazza/lucenenet/blob/docfx-apidocs/websites/site/contributing/mailing-lists.md/#L1" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/apache/lucenenet/blob/master/websites/site/contributing/mailing-lists.md/#L1" class="contribution-link">Improve this Doc</a>
                   </li>
                 </ul>
               </div>

--- a/contributing/source.html
+++ b/contributing/source.html
@@ -92,7 +92,7 @@
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/Shazwazza/lucenenet/blob/docfx-apidocs/websites/site/contributing/source.md/#L1" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/apache/lucenenet/blob/master/websites/site/contributing/source.md/#L1" class="contribution-link">Improve this Doc</a>
                   </li>
                 </ul>
               </div>

--- a/contributing/wiki.html
+++ b/contributing/wiki.html
@@ -84,7 +84,7 @@
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/Shazwazza/lucenenet/blob/docfx-apidocs/websites/site/contributing/wiki.md/#L1" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/apache/lucenenet/blob/master/websites/site/contributing/wiki.md/#L1" class="contribution-link">Improve this Doc</a>
                   </li>
                 </ul>
               </div>

--- a/docs.html
+++ b/docs.html
@@ -73,7 +73,7 @@
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/Shazwazza/lucenenet/blob/docfx-apidocs/websites/site/docs.md/#L1" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/apache/lucenenet/blob/master/websites/site/docs.md/#L1" class="contribution-link">Improve this Doc</a>
                   </li>
                 </ul>
               </div>

--- a/download/download.html
+++ b/download/download.html
@@ -91,7 +91,7 @@
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/Shazwazza/lucenenet/blob/docfx-apidocs/websites/site/download/download.md/#L1" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/apache/lucenenet/blob/master/websites/site/download/download.md/#L1" class="contribution-link">Improve this Doc</a>
                   </li>
                 </ul>
               </div>

--- a/download/version-2.html
+++ b/download/version-2.html
@@ -92,7 +92,7 @@
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/Shazwazza/lucenenet/blob/docfx-apidocs/websites/site/download/version-2.md/#L1" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/apache/lucenenet/blob/master/websites/site/download/version-2.md/#L1" class="contribution-link">Improve this Doc</a>
                   </li>
                 </ul>
               </div>

--- a/download/version-3.html
+++ b/download/version-3.html
@@ -121,7 +121,7 @@ are also provided as alternative verification method.</p>
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/Shazwazza/lucenenet/blob/docfx-apidocs/websites/site/download/version-3.md/#L1" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/apache/lucenenet/blob/master/websites/site/download/version-3.md/#L1" class="contribution-link">Improve this Doc</a>
                   </li>
                 </ul>
               </div>

--- a/download/version-4.html
+++ b/download/version-4.html
@@ -132,7 +132,7 @@
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/Shazwazza/lucenenet/blob/docfx-apidocs/websites/site/download/version-4.md/#L1" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/apache/lucenenet/blob/master/websites/site/download/version-4.md/#L1" class="contribution-link">Improve this Doc</a>
                   </li>
                 </ul>
               </div>

--- a/manifest.json
+++ b/manifest.json
@@ -53,7 +53,7 @@
       "output": {
         ".html": {
           "relative_path": "contributing/current-status.html",
-          "hash": "Mpw0HF9b9hC0sYrXg7t8sg=="
+          "hash": "TsGPLdiFDBcyHMFA3PZrrg=="
         }
       },
       "is_incremental": false,
@@ -65,7 +65,7 @@
       "output": {
         ".html": {
           "relative_path": "contributing/documentation.html",
-          "hash": "HenDvsUp/1ZS8U9m3qPC9g=="
+          "hash": "S3moP0l0x9B+Wp+XXUNSSQ=="
         }
       },
       "is_incremental": false,
@@ -77,7 +77,7 @@
       "output": {
         ".html": {
           "relative_path": "contributing/index.html",
-          "hash": "/e2NczhDhCpMaigb8cKUTw=="
+          "hash": "tzFXnBdEb+J2fLSRccr5oQ=="
         }
       },
       "is_incremental": false,
@@ -89,7 +89,7 @@
       "output": {
         ".html": {
           "relative_path": "contributing/issue-tracker.html",
-          "hash": "MnAaqhDSSDlCorb38pId5w=="
+          "hash": "ymunYXN9yB7R+Ui2KDEZxQ=="
         }
       },
       "is_incremental": false,
@@ -101,7 +101,7 @@
       "output": {
         ".html": {
           "relative_path": "contributing/mailing-lists.html",
-          "hash": "tcPiQ6yvGDcg8a1p+RCdxg=="
+          "hash": "8hXm7pSUVpjiHePqnpW4Xg=="
         }
       },
       "is_incremental": false,
@@ -113,7 +113,7 @@
       "output": {
         ".html": {
           "relative_path": "contributing/source.html",
-          "hash": "dMXa5GGMEzXpswPe4KsAHw=="
+          "hash": "gPJRp25HAtzuv5sOV5RrTw=="
         }
       },
       "is_incremental": false,
@@ -125,7 +125,7 @@
       "output": {
         ".html": {
           "relative_path": "contributing/toc.html",
-          "hash": "jQpNWKEh+Nadm1V1Zem4Cg=="
+          "hash": "S6rpztM6ysexbX1hZQUd0A=="
         }
       },
       "is_incremental": false,
@@ -137,7 +137,7 @@
       "output": {
         ".html": {
           "relative_path": "contributing/wiki.html",
-          "hash": "aOVqpkqwxkvgxgL6gcm+DA=="
+          "hash": "TVnkpOaTP5GfvCaCz9xXIw=="
         }
       },
       "is_incremental": false,
@@ -149,7 +149,7 @@
       "output": {
         ".html": {
           "relative_path": "docs.html",
-          "hash": "ANM+noJl0Bsfxm2ZXhI4CA=="
+          "hash": "omSz1JSpCU6mLcyFrLC07g=="
         }
       },
       "is_incremental": false,
@@ -161,7 +161,7 @@
       "output": {
         ".html": {
           "relative_path": "download/download.html",
-          "hash": "Almp6tWYpwYoF4e+lpdJjA=="
+          "hash": "2p9nwpDaA5AW+5n8LVwtZg=="
         }
       },
       "is_incremental": false,
@@ -185,7 +185,7 @@
       "output": {
         ".html": {
           "relative_path": "download/version-2.html",
-          "hash": "CUM+ulNS5++uVIITVsT3Zw=="
+          "hash": "g+fKFRGnEvPtV0veQVAM9w=="
         }
       },
       "is_incremental": false,
@@ -197,7 +197,7 @@
       "output": {
         ".html": {
           "relative_path": "download/version-3.html",
-          "hash": "c2TqOZZaoqvwmukCGHeBAQ=="
+          "hash": "WXErDymTSKWtFMokEbZytw=="
         }
       },
       "is_incremental": false,
@@ -209,7 +209,7 @@
       "output": {
         ".html": {
           "relative_path": "download/version-4.html",
-          "hash": "hGJFhTvnFXe4DxG9c+vbTw=="
+          "hash": "fIYG7A94ssnkx8XkUTkgCw=="
         }
       },
       "is_incremental": false,
@@ -221,7 +221,18 @@
       "output": {
         ".html": {
           "relative_path": "index.html",
-          "hash": "yhochYWTL62fvo8w35FQcg=="
+          "hash": "OvJKXIUTycezWOnf0MLCSg=="
+        }
+      },
+      "is_incremental": false,
+      "version": ""
+    },
+    {
+      "type": "Resource",
+      "source_relative_path": "lucenetemplate/doap_Lucene_Net.rdf",
+      "output": {
+        "resource": {
+          "relative_path": "doap_Lucene_Net.rdf"
         }
       },
       "is_incremental": false,
@@ -253,13 +264,13 @@
           "details": "Processor TocDocumentProcessor cannot support incremental build because the processor doesn't implement ISupportIncrementalDocumentProcessor interface.",
           "incrementalPhase": "build"
         },
+        "ConceptualDocumentProcessor": {
+          "can_incremental": false,
+          "incrementalPhase": "build"
+        },
         "ResourceDocumentProcessor": {
           "can_incremental": false,
           "details": "Processor ResourceDocumentProcessor cannot support incremental build because the processor doesn't implement ISupportIncrementalDocumentProcessor interface.",
-          "incrementalPhase": "build"
-        },
-        "ConceptualDocumentProcessor": {
-          "can_incremental": false,
           "incrementalPhase": "build"
         }
       }


### PR DESCRIPTION
This fixes the improve this doc button, this is the site output based on this change https://github.com/apache/lucenenet/pull/225 ... which also needs to be merged into the main repo