### PR TITLE
Updating .asf.yaml to be compliant with apache infra

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,5 +1,15 @@
 # Apache YAML Features for Git Repositories
-# See the documentation at: https://cwiki.apache.org/confluence/display/INFRA/.asf.yaml+features+for+git+repositories
+# See the documentation: 
+#  https://cwiki.apache.org/confluence/display/INFRA/.asf.yaml+features+for+git+repositories
+#  https://cwiki.apache.org/confluence/display/INFRA/Git+-+.asf.yaml+features#Git.asf.yamlfeatures-WebSiteDeploymentServiceforGitRepositories
+
+# Staging and publishing profile for yourproject-website.git:
+staging:
+  profile: ~
+  whoami:  asf-staging
+ 
+publish:
+  whoami:  asf-site
 
 github:
   description: "Apache Lucene.NET Website"


### PR DESCRIPTION
This adds the changes to support the apache infra change request. This also then provides the ability to have a staging site if/when we want to do that. The docs for staging are here https://cwiki.apache.org/confluence/display/INFRA/Git+-+.asf.yaml+features#Git.asf.yamlfeatures-WebSiteDeploymentServiceforGitRepositories 

For the time being though, I think this change satisfies the apache infra requirements.

Part of the requirements is:

> It is important to note that the .asf.yaml file MUST be present at the
root of the file system in the branch you wish to publish. The 'whoami'
parameter acts as a guard, ensure that only the intended branch is used
for publishing.

which I think means that this file must be in the root of the asf-site branch (and any other branch that hosts the site, like staging eventually). Probably should commit to master and merge up to asf-site. Though it would be nice to make asf-site the default branch since we only really ever use that but I'm unsure how to do that.

Let me know what you think.