### PR TITLE
improved content of /contributing/source web page

### DIFF
--- a/contributing/source.html
+++ b/contributing/source.html
@@ -8,7 +8,7 @@
     <title>Source code | Apache Lucene.NET 4.8.0 </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Source code | Apache Lucene.NET 4.8.0 ">
-    <meta name="generator" content="docfx 2.58.0.0">
+    <meta name="generator" content="docfx 2.50.0.0">
     
     <link rel="shortcut icon" href="../logo/favicon.ico">
     <link rel="stylesheet" href="../styles/docfx.vendor.css">
@@ -76,15 +76,28 @@
 
 <hr>
 <h2 id="git-repository">Git repository</h2>
-<p>Apache Lucene.Net uses git as its source code management system.</p>
-<p>The official repository is here: <strong><a href="https://git-wip-us.apache.org/repos/asf?p=lucenenet.git">https://git-wip-us.apache.org/repos/asf?p=lucenenet.git</a></strong>.</p>
-<p>You can clone the repo with the command line or your favorite Git client, example:</p>
-<pre><code>git clone https://git-wip-us.apache.org/repos/asf/lucenenet.git
+<p>Apache Lucene.Net uses git as its source code management system.  More specifically, it use Apache's <a href="https://git.apache.org/">two-master</a> setup with a master repo on <a href="https://github.com/apache/lucenenet">GitHub</a> and on <a href="https://gitbox.apache.org/repos/asf?p=lucenenet.git">GitBox</a>. Either repo may be used for commits and pull requests as they automatically sync with one and other.</p>
+<p>In practice, the team primarily uses the GitHub repo at <strong><a href="https://github.com/apache/lucenenet">https://github.com/apache/lucenenet</a></strong> for it's work. You can find current issues that need worked on in the <a href="https://github.com/apache/lucenenet/issues">issues list</a> there.</p>
+<h2 id="setting-up-your-fork">Setting Up Your Fork</h2>
+<p>If you would like to contribute to the project, typically the first thing you will want to do is to <a href="https://docs.github.com/en/get-started/signing-up-for-github/signing-up-for-a-new-github-account">create a github account</a> and then <a href="https://docs.github.com/en/get-started/quickstart/fork-a-repo">fork</a> the apache/LuceneNET GitHub repo.  Forking the repo will place a copy of the repo (the &quot;Fork&quot;) in your GitHub account. A fork is a copy of a repository that you manage.</p>
+<p>You use this fork to make changes without affecting the upstream repository. For more information, see GitHub Docs &quot;<a href="https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks">Working with forks</a>.&quot;</p>
+<h2 id="cloning-that-fork">Cloning that Fork</h2>
+<p>Next, you will typically clone that forked repo from your GitHub account so that you have a clone of it on your local machine to work with.  If you are unfamiliar with cloning a GitHub repo see GitHub Docs <a href="https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository">&quot;Cloning a repository&quot;</a>.  The git command for cloning the repo is:</p>
+<pre><code>$ git clone https://github.com/YOUR-GITHUB-USERNAME/lucenenet.git
 </code></pre>
-<p>There also is a mirror at GitHub <strong><a href="https://github.com/apache/lucene.net">https://github.com/apache/lucene.net</a></strong> which is synced from the Apache repository.</p>
-<p>Most work currently happens on the branch named <strong>branch_4x</strong>.</p>
+<p>At this point you have a local copy of the Lucene.NET repo on your development machine.<br>
+Most work currently happens on the branch named <strong>master</strong>. But typically you will create a new branch on your local repo for the changes you'd like to make and you will ultimately do a pull request to get that branch merged back into master.  More about that later.</p>
 <h2 id="building--testing">Building &amp; testing</h2>
-<p>The guide for building/testing is currently in the Git repository <strong><a href="https://github.com/apache/lucenenet/blob/master/README.md#building-and-testing">here</a></strong></p>
+<p>It's totally possible to build the project and run the unit tests all from the command line.  You can find documentation for doing that in the Git repository <strong><a href="https://github.com/apache/lucenenet/blob/master/README.md#building-and-testing">here</a></strong>.</p>
+<p>However, it's common for developers to build and test the project using Visual Studio by opening the <code>Lucene.Net.sln</code> solution file located in the root of the local repo.  Some developers are currently using Visual Studio 2019 and some are using Visual Studio 2022. You may use whichever you prefer.</p>
+<p>Once the solution has been opened in Visual Studio you can build it as you would any solution by selecting &quot;Build Solution&quot; from the &quot;Build&quot; menu. Likewise you can run the unit tests for the solution just like you would for any other solution by selecting &quot;Run All Tests&quot; from the &quot;Tests&quot; menu.</p>
+<p>This is a large solution with more than 300K lines of code so it may take a bit longer for Visual Studio to perform these operations then you are use to but it should display progress information while it does it work.</p>
+<h2 id="making-changes">Making Changes</h2>
+<p>If you would like to make a change to the source code or other files, typically you will first make a new branch in your local repository. Then make the changes in that branch and commit them to your local repository.  If there are several different types of changes you'd like to make it's best to put each type of change into a seperate commit so that each commit description can be more specific.</p>
+<h2 id="contributing-your-changes-back">Contributing Your Changes Back</h2>
+<p>Once you have made your change to a newly created branch of your local repo, push those changes to the remote repository located in your GitHub account.  Then visit that your GitHub repo via the browser and it should display a button you can click to compare it to the upstream repo (ie. the apache/lucenenet rep you forked from) and to submit a pull request.  That pull request (PR) is your way of letting the Lucene.NET core team know you have a contribution that you would like to have merged into the official Lucene.NET repo.</p>
+<p>Someone will get back to you with feedback if needed, or will directly merge your changes into the official repo.  Any action they take on the PR will trigger an email to the email address of your GitHub account so that you have visibility as to what's going on with your submission.</p>
+<p>In addition to what has been written here, there are lots of blog post on the web about how to get started with Open Source like <a href="https://www.freecodecamp.org/news/how-to-contribute-to-open-source-projects-beginners-guide/">this one</a> which provides a great orientation and top level overview.</p>
 </article>
           </div>
           
@@ -98,8 +111,7 @@
                 </ul>
               </div>
               <nav class="bs-docs-sidebar hidden-print hidden-xs hidden-sm affix" id="affix">
-                <h5>In This Article</h5>
-                <div></div>
+              <!-- <p><a class="back-to-top" href="#top">Back to top</a><p> -->
               </nav>
             </div>
           </div>


### PR DESCRIPTION
Update the page to show current information about the Apache's two-master setup and provided additional information about contributing source code with many links to external references. This is pretty much a rewrite of the page.